### PR TITLE
Compatibility with GHC 9.2

### DIFF
--- a/Numeric/NumType/DK/Integers.hs
+++ b/Numeric/NumType/DK/Integers.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE AutoDeriveTypeable #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}


### PR DESCRIPTION
According to http://downloads.haskell.org/ghc/9.2.1-alpha2/docs/html/users_guide/9.2.1-notes.html#language:

> Previously, `-XUndecidableInstances` accidentally implied `-XFlexibleContexts`. This is now fixed, but it means that some programs will newly require `-XFlexibleContexts`.